### PR TITLE
[chore] Core Module 추가 

### DIFF
--- a/Domado/Core/.gitignore
+++ b/Domado/Core/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Domado/Core/Package.swift
+++ b/Domado/Core/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Core",
+    defaultLocalization: "en",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+       
+        .library(
+            name: "Core",
+            type: .dynamic,
+            targets: ["Core"]),
+    ],
+    targets: [
+        .target(
+            name: "Core"),
+        .testTarget(
+            name: "CoreTests",
+            dependencies: ["Core"]
+        ),
+    ]
+)

--- a/Domado/Core/Sources/Core/Core.swift
+++ b/Domado/Core/Sources/Core/Core.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Domado/Core/Sources/Core/Error/AppError.swift
+++ b/Domado/Core/Sources/Core/Error/AppError.swift
@@ -1,0 +1,7 @@
+//
+//  AppError.swift
+//  Core
+//
+//  Created by 이종선 on 9/22/24.
+//
+

--- a/Domado/Core/Sources/Core/Extensions/Date+Extension.swift
+++ b/Domado/Core/Sources/Core/Extensions/Date+Extension.swift
@@ -1,0 +1,7 @@
+//
+//  Date+Extension.swift
+//  Core
+//
+//  Created by 이종선 on 9/22/24.
+//
+

--- a/Domado/Core/Sources/Core/Extensions/View+Extension.swift
+++ b/Domado/Core/Sources/Core/Extensions/View+Extension.swift
@@ -1,0 +1,7 @@
+//
+//  View+Extension.swift
+//  Core
+//
+//  Created by 이종선 on 9/22/24.
+//
+

--- a/Domado/Core/Sources/Core/Logging/AppLogger.swift
+++ b/Domado/Core/Sources/Core/Logging/AppLogger.swift
@@ -1,0 +1,7 @@
+//
+//  AppLogger.swift
+//  Core
+//
+//  Created by 이종선 on 9/22/24.
+//
+

--- a/Domado/Core/Sources/Core/UI/CustomFont.swift
+++ b/Domado/Core/Sources/Core/UI/CustomFont.swift
@@ -1,0 +1,7 @@
+//
+//  CustomFont.swift
+//  Core
+//
+//  Created by 이종선 on 9/22/24.
+//
+

--- a/Domado/Core/Tests/CoreTests/CoreTests.swift
+++ b/Domado/Core/Tests/CoreTests/CoreTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Core
+
+final class CoreTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}

--- a/Domado/Domado.xcodeproj/project.pbxproj
+++ b/Domado/Domado.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AF5E248C2C9FB44B00FA2DA5 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = AF5E248B2C9FB44B00FA2DA5 /* Core */; };
+		AF5E248D2C9FB44B00FA2DA5 /* Core in Embed Frameworks */ = {isa = PBXBuildFile; productRef = AF5E248B2C9FB44B00FA2DA5 /* Core */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		AF8F62242C90939C00D6E8E2 /* DomadoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62232C90939C00D6E8E2 /* DomadoApp.swift */; };
 		AF8F62262C90939C00D6E8E2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62252C90939C00D6E8E2 /* ContentView.swift */; };
 		AF8F62282C90939E00D6E8E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF8F62272C90939E00D6E8E2 /* Assets.xcassets */; };
@@ -32,7 +34,22 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		AF5E248E2C9FB44B00FA2DA5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				AF5E248D2C9FB44B00FA2DA5 /* Core in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		AF5E24892C9F1C5700FA2DA5 /* Core */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Core; sourceTree = "<group>"; };
 		AF8F62202C90939C00D6E8E2 /* Domado.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Domado.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF8F62232C90939C00D6E8E2 /* DomadoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomadoApp.swift; sourceTree = "<group>"; };
 		AF8F62252C90939C00D6E8E2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -49,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF5E248C2C9FB44B00FA2DA5 /* Core in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,12 +87,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AF5E248A2C9FB44B00FA2DA5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		AF8F62172C90939C00D6E8E2 = {
 			isa = PBXGroup;
 			children = (
+				AF5E24892C9F1C5700FA2DA5 /* Core */,
 				AF8F62222C90939C00D6E8E2 /* Domado */,
 				AF8F62332C90939E00D6E8E2 /* DomadoTests */,
 				AF8F623D2C90939E00D6E8E2 /* DomadoUITests */,
+				AF5E248A2C9FB44B00FA2DA5 /* Frameworks */,
 				AF8F62212C90939C00D6E8E2 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -126,6 +153,7 @@
 				AF8F621C2C90939C00D6E8E2 /* Sources */,
 				AF8F621D2C90939C00D6E8E2 /* Frameworks */,
 				AF8F621E2C90939C00D6E8E2 /* Resources */,
+				AF5E248E2C9FB44B00FA2DA5 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -604,6 +632,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AF5E248B2C9FB44B00FA2DA5 /* Core */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Core;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AF8F62182C90939C00D6E8E2 /* Project object */;
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)

### SwiftPackageManager를 사용해서 `Core` 모듈을 추가했습니다. 
- `Core`의 `Package.swift` 파일을 통해 모듈의 swiftToolVersion, defaultLocalization, platform, product, target 을 구성했습니다. 
- `Target` > `General` > `Framework, Libraries and Embedded Content` 에서 `Core` 라이브러리를 추가했습니다.  앱의 서명으로 다시 모듈에 대한 서명을 하는 옵션인 `Embed & Sign`옵션을 선택했습니다. 
- `Core`에 대한 Test를 만들고 `Core`의 `Package.swift` 파일을 이용해 모듈에 대한 테스트 타겟을 지정했습니다. 

### `Core` 모듈에 들어갈것이라고 예상되는 기능들에 대한 폴더링을 했습니다. 
- `Error`:  앱 전반에 걸쳐 계층화된 에러를 위한 root Error를 제공합니다. 
- `Extensions`: 앱 전체에서 사용되는 확장 기능을 제공합니다. 
- `Logging` : 앱 전체에서 활용되는 Log 기능을 제공합니다. 
- `UI` : 폰트, 색상 같은 UI 요소와 함께 `LoadingView`, 'ErrorAlertView', `EmptyView`등을 앱 전체에서 재사용 될 수 있는 View를 제공합니다. 


## 🟠 변경 이유 (Why)
- 모듈화를 통해 기능 단위로 독립적인 개발이 이루어질 수 있도록합니다.
- 각 모듈로 격리를 통해 모듈 자체로 테스트가 가능하도록 인터페이스를 적극적으로 사용합니다. 
- `Core` 모듈을 이용해 앱 전체에 걸쳐 사용되는 기능을 구조화합니다. 


## 🟡 테스트 방법 (How to Test)
### Scheme 생성 
1. Xcode 상단의 Scheme 선택 메뉴를 클릭합니다.
2. "New Scheme"을 선택합니다.
3. 새 Scheme의 이름을 입력합니다 


### Scheme 설정
1. 생성된 Scheme을 선택한 상태에서 "Edit Scheme"을 클릭합니다.
2. 왼쪽 사이드바에서 "Test"를 선택합니다.
3. "Info" 탭에서 테스트하려는 타겟이 체크되어 있는지 확인합니다.


### 테스트 실행을 위한 Scheme 선택
Xcode 상단의 Scheme 선택 메뉴에서 방금 생성한 테스트 Scheme을 선택합니다.


### 테스트 실행
Command + U를 누르거나 Product > Test 메뉴를 선택하여 테스트를 실행합니다.


## 🟢 추가 노트 (Additional Notes)
- 이후 `Package.swift` 파일을 통하여 패키지간의 의존관계를 설정합니다. 
- 각 모듈마다 별도의 테스트 Scheme을 만들 수 있습니다. 이렇게 하면 특정 모듈의 테스트만 실행할 수 있어 효율적입니다.
- Scheme에서는 테스트 실행 환경(예: 시뮬레이터 또는 실제 기기)도 지정할 수 있습니다.
- 여러 모듈의 테스트를 한 번에 실행하고 싶다면, 하나의 Scheme에 여러 테스트 타겟을 포함시킬 수 있습니다.
- CI/CD 파이프라인을 구성할 때 이 Scheme들을 활용하여 자동화된 테스트를 실행할 수 있습니다.
